### PR TITLE
Addresses Issue #1, as well as adding basic end-to-end tests for the converter script.

### DIFF
--- a/nanodesign/converters/cadnano/convert_design.py
+++ b/nanodesign/converters/cadnano/convert_design.py
@@ -499,7 +499,7 @@ class CadnanoConvertDesign(object):
         next_coords = curr_coords + [0, -dist_bp*helix_axis[1], 0]
         rot_mat = vrrotvec2mat(y_up_vec, deg2rad(ang_bp))
         next_frame = np.dot(rot_mat,curr_frame)
-        [insert_coords, insert_frames] = _bp_interp(curr_coords, curr_frame, next_coords, next_frame, num_inserts/2)
+        [insert_coords, insert_frames] = bp_interp(curr_coords, curr_frame, next_coords, next_frame, num_inserts/2)
         self._logger.debug("Insert dsDNA")
         self._logger.debug("num_inserts %d " % num_inserts)
         self._logger.debug("next_coords %s" % str(next_coords))

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright 2016 Autodesk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is a shortcut to run the tests and produce the JUnitXML output to
+# stdout. This is needed for Jenkins CI automation of the tests.
+
+python -m pytest --tb=short tests_basic.py --junitxml=output.xml >> /dev/null
+export code=$?
+cat output.xml
+exit $code
+

--- a/tests/run_tests_jenkins.sh
+++ b/tests/run_tests_jenkins.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright 2016 Autodesk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is a shortcut to run the tests and produce the JUnitXML output to
+# stdout. This is needed for Jenkins CI automation of the tests.
+
+python -m pytest --tb=short tests_basic.py --junitxml=output.xml >> /dev/null
+export code=$?
+cat output.xml
+rm output.xml
+exit $code
+

--- a/tests/tests_basic.py
+++ b/tests/tests_basic.py
@@ -12,3 +12,149 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+import subprocess
+
+import os.path
+import hashlib
+
+###################
+# Setup path data #
+###################
+
+tests_path = os.path.dirname( os.path.abspath( __file__ ))
+samples_path = os.path.join( tests_path, 'samples/')
+base_path = os.path.abspath( os.path.join( tests_path, '../' ))
+scripts_path = os.path.join( base_path, 'scripts/')
+
+####################
+# Helper Functions #
+####################
+
+def fast_hash_file( filename ):
+    md5 = hashlib.md5()
+    with open(filename, 'rb') as f:
+        while True:
+            data = f.read( 1048576 )  # 1 MB
+            if not data:
+                break
+            md5.update( data )
+    return md5.hexdigest()
+
+# Note on master hashfile formats used here:
+#
+# We assume that the first entry, the filename, has no path information. It
+# currently is assumed to reside in the tests/samples/ directory, but in the
+# future we may make there be subdirectories there. If we do so, we will need to
+# examine the functions and fixtures here that call os.path.basename, as well as
+# the samples_path variable, and possibly more.
+
+def load_master_hashfile(filename = "tests_master_hashfile.txt"):
+    file_path = os.path.join( tests_path, filename )
+    lines = []
+    master = {}
+    with open( file_path, 'rt') as f:
+        lines = f.readlines()
+        
+    for line in lines:
+        segments = line.split()
+        name = segments[0]
+        hashes = {}
+        for segment in segments[1:]:
+            key,value = segment.split(':')
+            hashes[key] = value
+        master[name] = hashes
+    return master
+
+def add_to_hashfile( hashfile, file_path, key, value ):
+    filename = os.path.basename( file_path )    
+    try:
+        hashfile[filename][key] = value
+    except KeyError:
+        hashfile[filename] = {}
+        hashfile[filename][key] = value
+   
+
+def save_master_hashfile():
+    pass
+
+
+#######################
+# Setup Hashfile Data #
+#######################
+
+master_hashfile = load_master_hashfile()
+current_tests_hashfile = {}
+
+############
+# Fixtures #
+############
+
+
+@pytest.fixture(scope="module",
+                params=["fourhelix.json", "flat_sheet.json","beachball.json"])
+def sample_file( request ):
+    return os.path.join(samples_path, request.param)
+
+
+
+@pytest.fixture()
+def basic_converter_hash( sample_file ):
+    filename = os.path.basename( sample_file ) 
+    try:
+        return master_hashfile[filename]['converter_basic']
+    except KeyError:
+        return None
+
+
+#########
+# Tests #
+#########
+
+def test_convert_basic( sample_file, basic_converter_hash ):
+    converter_file = os.path.join( scripts_path, 'converter.py' )
+    result = subprocess.call([converter_file,"--infile", sample_file , "--informat", "cadnano", "--inseqname", "M13mp18","--outfile", "my_sample_viewer.json", "--outformat", "viewer"] , stdout=None, stderr=None)
+    # First way it could fail is if the call did not succeed, e.g. some error while executing.
+    assert result == 0
+
+    # Second way it could fail is if the md5 hash was different.
+    # result = subprocess.check_output(['md5','-q','my_sample_viewer.json'])
+    # result = result.rstrip('\n')
+    # assert result == md5_hash
+
+    result = fast_hash_file('my_sample_viewer.json')
+    add_to_hashfile( current_tests_hashfile, sample_file, 'converter_basic', result )
+    assert result == basic_converter_hash, "Hash value mismatch."
+
+
+def test_convert_modify():
+    filename = os.path.join( samples_path, 'flat_sheet.json' )
+    converter_file = os.path.join( scripts_path, 'converter.py' )
+    result = subprocess.call([converter_file,"--infile", filename , "--informat", "cadnano", "--inseqname", "M13mp18","--modify","true","--outfile", "my_sample_viewer.json", "--outformat", "viewer"] , stdout=None, stderr=None)
+    # First way it could fail is if the call did not succeed, e.g. some error while executing.
+    assert result == 0
+
+    result = fast_hash_file('my_sample_viewer.json')
+    add_to_hashfile( current_tests_hashfile, filename, 'converter_modify', result )
+    assert result == master_hashfile['flat_sheet.json']['converter_modify'], "Hash value mismatch."
+
+
+
+def test_show_hashes( capsys ):
+    """This is a dummy test that should be run last. It will always fail, and will
+show hash information in the stdout section of its failure report."""
+
+    if capsys is not None:
+        out,err = capsys.readouterr()
+
+    import pprint
+    pprint.pprint(current_tests_hashfile)
+
+    # Change this line if you want to get a printout of all hashes processed.
+    assert 0 == 0
+
+
+
+
+
+    

--- a/tests/tests_master_hashfile.txt
+++ b/tests/tests_master_hashfile.txt
@@ -1,0 +1,3 @@
+fourhelix.json   converter_basic:3085a71a3a12bda14c9d3c614494acc3
+flat_sheet.json  converter_basic:f4ba35f13c89f3fdbb44955dd61dea8c converter_modify:a2fbe90bd4a22d139eadc3f6ef7c4775
+beachball.json   converter_basic:12fdedb5a727a85e28fffb739844d4c9


### PR DESCRIPTION
This fixes the typo that caused issue #1, and starts adding
end-to-end tests for the scripts. It does these end-to-end tests
within the [http://doc.pytest.org/] framework by setting
up test cases that make subprocess calls to the converter script
and monitor the exit code as well as the resulting output
file. The output file is hashed, and compared to a master
list (kept in [tests/tests_master_hashfile.txt]) to ensure that the
output has not changed.

Currently this only runs three very basic conversion tests, as
well as a single test of the modify flag to the converter, on the
[tests/samples/flat_sheet.json] file, which includes both inserts
and deletes. This latter test would catch Issue #1 and produce an
error if it should happen again.